### PR TITLE
Fix run-test-package ran from other packages

### DIFF
--- a/cl-test-more.lisp
+++ b/cl-test-more.lisp
@@ -295,11 +295,10 @@ CL-TEST-MORE is freely distributable under the MIT License (http://www.opensourc
         (error "Not found test: ~a" (car test)))))
 
 (defun run-test-package (package)
-  (plan (handler-case (symbol-value (intern (string :*plan*) package))
-          (unbound-variable () :unspecified)))
   (loop for (name . nil) in (find-tests-of-package package)
         do (run-test name))
-  (finalize))
+  (let ((*package* (find-package package)))
+    (finalize)))
 
 (defun run-test-all ()
   "DEPRECATED!"


### PR DESCRIPTION
In run-test-package, finalize is called with the current package. That means
it's looking for _counter_ in _package_ rather than in the package running
tests. Using let, we bind _package_ temporarily to the target package and
call finalize. Consequently, we also have access to _plan_ from this
package, so we don't need to call in caller's _package_ and pollute it.
