### PR TITLE
(Kind of) added support for alist in is-expand expansions

### DIFF
--- a/src/test.lisp
+++ b/src/test.lisp
@@ -243,8 +243,10 @@
               t))
         (equal x y)))
   (:method ((x cons) (y cons))
-    (loop for a in x for b in y
-          always (gensym-tree-equal a b))))
+    (if (consp (cdr x))
+        (loop for a in x for b in y
+           always (gensym-tree-equal a b))
+        (equal x y))))
 
 (defmacro is-expand (got expected &optional desc)
   (with-gensyms (duration expanded)


### PR DESCRIPTION
`is-expand` doesn't have support for alists:
```lisp
(defmacro my-macro (stuff)
  `(PROGN (SETF ,stuff
               '((a . problem-here)))))
; => MY-MACRO
(is-expand (my-macro here)
           (PROGN (SETF HERE '((A . PROBLEM-HERE)))))
; => TYPE-ERROR
(PROVE.TEST::GENSYM-TREE-EQUAL '(A . PROBLEM-HERE) '(A . PROBLEM-HERE))
; => TYPE-ERROR
```

The problem is in the body of the sencod dispatch case of the `gensym-tree-equal` function:
```lisp
(defgeneric gensym-tree-equal (x y)
  (:method (x y)
    (if (and (gensymp y) (symbolp x))
        (if (assoc y *gensym-alist*)
            (eq x (cdr (assoc y *gensym-alist*)))
            (unless (rassoc x *gensym-alist*)
              (setf *gensym-alist* `((,y . ,x) ,@*gensym-alist*))
              t))
        (equal x y)))
  (:method ((x cons) (y cons))
    (loop for a in x for b in y
       always (gensym-tree-equal a b))))
```
The `loop` macro destructures the `x` and `y` lists, walking accros those lists, but they assume that both lists aren't dotted: 
```lisp
(loop for x in '(a . b) for y in '(a . b)
   always (progn (print x)
                 (print y)))
; => TYPE-ERROR
```
Maybe this isn't the best fix, but it does the job, as far as I could see.