### PR TITLE
ok evals test twice

### DIFF
--- a/src/test.lisp
+++ b/src/test.lisp
@@ -151,8 +151,7 @@
            (test ,result t ,desc
                  :duration ,duration
                  :test-fn (lambda (x y)
-                            (eq (not (null x)) y))
-                 :got-form ,test))))))
+                            (eq (not (null x)) y))))))))
 
 (defmacro is (got expected &rest args)
   (with-gensyms (duration result new-args desc)


### PR DESCRIPTION
```
(is  (print "1") "1")

"1" Q
  ✓ "1" is expected to be "1" 
T
#<PASSED-TEST-REPORT RESULT: T, GOT: "1", EXPECTED: "1">
TEST> (ok  (print "1") )

"1" 
"1" 
  ✓ "1" is expected to be T 
T
#<PASSED-TEST-REPORT RESULT: T, GOT: "1", EXPECTED: T>
```