### PR TITLE
Use MAKE-SYNONYM-STREAM for *TEST-RESULT-OUTPUT*

### DIFF
--- a/src/output.lisp
+++ b/src/output.lisp
@@ -6,12 +6,7 @@
            :*default-reporter*))
 (in-package :prove.output)
 
-(defvar *test-result-output* t)
-
-(defun test-result-output ()
-  (if (eq *test-result-output* t)
-      *standard-output*
-      *test-result-output*))
+(defvar *test-result-output* (make-synonym-stream '*standard-output*))
 
 ;; This should be in prove.reporter,
 ;; but it's here because this will also be used in prove-asdf.

--- a/src/suite.lisp
+++ b/src/suite.lisp
@@ -2,7 +2,7 @@
 (defpackage prove.suite
   (:use :cl)
   (:import-from :prove.output
-                :test-result-output)
+                :*test-result-output*)
   (:import-from :prove.report
                 :report
                 :failed-report-p)
@@ -82,11 +82,11 @@
   (let ((suite (current-suite)))
     (setf (slot-value suite 'plan) num)
     (reset-suite suite))
-  (print-plan-report nil num (test-result-output)))
+  (print-plan-report nil num *test-result-output*))
 
 (defun finalize (&optional (suite (current-suite)))
   (with-slots (plan reports failed) suite
-    (print-finalize-report nil plan reports (test-result-output))
+    (print-finalize-report nil plan reports *test-result-output*)
     (setf *last-suite-report*
           (list :plan plan :failed failed))
     (zerop failed)))

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -2,7 +2,7 @@
 (defpackage prove.test
   (:use :cl)
   (:import-from :prove.output
-                :test-result-output)
+                :*test-result-output*)
   (:import-from :prove.report
                 :test-report-p
                 :passed-test-report
@@ -114,7 +114,7 @@
         (incf (failed suite)))
       (incf (test-count suite))
       (when output
-        (format-report (test-result-output) nil report :count (test-count suite)))
+        (format-report *test-result-output* nil report :count (test-count suite)))
       (values result report))))
 
 (defmacro with-duration (((duration result) form) &body body)
@@ -266,7 +266,7 @@
   (let ((report (make-instance 'comment-report
                                :description desc)))
     (add-report report (current-suite))
-    (format-report (test-result-output) nil report)))
+    (format-report *test-result-output* nil report)))
 
 (defun skip (how-many why &rest format-args)
   (check-type how-many integer)
@@ -296,7 +296,7 @@
                                            :got e
                                            :description (format nil "Aborted due to an error in subtest ~S" desc))))
                       (add-report error-report *suite*)
-                      (format-report (test-result-output) nil error-report :count (test-count *suite*))))))
+                      (format-report *test-result-output* nil error-report :count (test-count *suite*))))))
             (make-instance 'composed-test-report
                            :duration (reduce #'+
                                              (remove-if-not #'test-report-p (reports *suite*))
@@ -307,7 +307,7 @@
         (suite (current-suite)))
     (add-report report suite)
     (incf (test-count suite))
-    (format-report (test-result-output) nil report :count (test-count suite))))
+    (format-report *test-result-output* nil report :count (test-count suite))))
 
 (defmacro subtest (desc &body body)
   `(%subtest ,desc (lambda () ,@body)))


### PR DESCRIPTION
This allows idiomatic use of *TEST-RESULT-OUTPUT* variable instead of
accessing its value through a function and setting it through a symbol.

See: http://lisptips.com/post/127524780849/when-a-synonym-stream-is-useful