### PR TITLE
Use getenv from the UIOP package instead of ASDF

### DIFF
--- a/prove.asd
+++ b/prove.asd
@@ -9,7 +9,8 @@
   :license "MIT"
   :depends-on (:cl-ppcre
                :cl-ansi-text
-               :alexandria)
+               :alexandria
+               #:uiop)
   :components ((:module "src"
                 :components
                 ((:file "prove" :depends-on ("output" "test" "suite" "asdf" "color"))

--- a/src/color.lisp
+++ b/src/color.lisp
@@ -8,7 +8,7 @@
 (in-package :prove.color)
 
 (defvar *enable-colors*
-  (not (equal (asdf::getenv "EMACS") "t"))
+  (not (equal (uiop:getenv "EMACS") "t"))
   "Flag whether colorize a test report. The default is T except on Emacs (SLIME).")
 
 (defmacro with-gray (stream &body body)


### PR DESCRIPTION
This is a minor change, but getenv is part of the public API of UIOP while it is internal to the ASDF package