### PR TITLE
Don't create an instance of of LOAD-SOURCE-OP

### DIFF
--- a/src/asdf.lisp
+++ b/src/asdf.lisp
@@ -47,7 +47,7 @@
           (format *test-result-output* "~2&Running a test file '~A'~%" (asdf:component-pathname c))
           (restart-case
               (progn
-                (asdf:perform (make-instance 'asdf:load-source-op) c)
+                (asdf:perform 'asdf:load-source-op c)
                 (unless *last-suite-report*
                   (warn "Test completed without 'finalize'd."))
                 (if (eql (getf *last-suite-report* :failed) 0)


### PR DESCRIPTION
instead pass the symbol ASDF:LOAD-SOURCE-OP directly to ASDF:PERFORM. Since
version 2.27 operations should only be created with
ASDF:MAKE-OPERATION. Creating an instance of an operation fails starting on
ASDF 3.2.

Closes #35 

Note taht ASDF defines a convenience method specializing on symbols for perform, so passing `asdf:load-source-op` will in turn call perform with `(make-operation 'asdf:load-source-op)`.