### PR TITLE
Multiline test descriptions and indentation for nested tests

### DIFF
--- a/src/reporter.lisp
+++ b/src/reporter.lisp
@@ -10,33 +10,124 @@
   (:export :*indent-level*
            :indent-space
            :format/indent
-
            :reporter
            :format-report
            :print-error-report
            :print-plan-report
-           :print-finalize-report))
+           :print-finalize-report
+           :with-additional-indent))
 (in-package :prove.reporter)
 
-(defparameter *indent-level* 0)
+(defparameter *indent-level* 0
+  "Level for nested test-cases output.
+   Number of spaces, added for each indentation level
+   is described in reporter's indent-space slot.
+
+   Also, macro shift-indent could be used to slightly
+   indent content inside the main indentation level.
+
+   full-indent = indent-space * indent-level + additional-indent
+
+   Here is an example of the output:
+
+   1|  x Blah minor.
+   2|    Next line of description:
+   3|
+   4|      x Nested test.
+   5|        Also has multiline description.
+
+   In this example, indent-space is 4, that is why
+   text on lines 1 and 4 have 4 spaces between the 'x'
+   horizontally.
+
+   Outputting the first line \"  x \", reporter sets
+   *additional-indent* to 4. That is why these additional
+   4 lines are prepended to the rest lines of the main
+   test case description.
+
+   When inner testcase runs, it increments *indent-level*,
+   which shifts output to another 4 spaces (indent-space)
+   to the right, simultaneously resetting *additional-indent*
+   to zero.
+
+   For nested test, reporter writes \"  x \" and again,
+   sets *additional-indent* to 4 and every other lines now
+   shifted by 1 * 4 + 4 = 8 spaces.
+")
+
+(defparameter *additional-indent* 0
+  "Number of spaces to add to each line. see *indent-level* docstring for full description.")
+
+(defvar *debug-indentation* nil
+  "If True, then indentation will have '=' and '-' symbols for main indentaion and additional, instead of spaces.")
 
 (defun indent (space &optional (count *indent-level*))
-  (make-string (* count space) :initial-element #\Space))
+  "Creates a string with a number of spaces to indent new line
+of a test report."
+  (if *debug-indentation*
+      (concatenate 'string
+                   (make-string (* count space)
+                                :initial-element #\=)
+                   (make-string *additional-indent*
+                                :initial-element #\-))
+      (make-string (+ (* count space)
+                                     *additional-indent*)
+                   :initial-element #\space)))
 
-(defun format/indent (reporter destination control-string &rest format-arguments)
-  (let ((output (apply #'format nil control-string format-arguments)))
-    (when (ppcre:scan "^~&" control-string)
-      (fresh-line destination))
-    (with-slots (indent-space) reporter
-      (format destination (indent indent-space))
+
+(defmacro with-additional-indent ((reporter stream control-string &rest format-arguments) &body body)
+  (declare (ignorable reporter stream control-string))
+  (let* ((need-new-line (ppcre:scan "^~&" control-string))
+         (string (apply #'format nil control-string format-arguments))
+         (increment (length string)))
+    `(with-slots (indent-space) reporter
+       (let* ((first-line-indent (indent indent-space))
+              (*additional-indent* ,(if need-new-line
+                                        increment
+                                        `(+ *additional-indent*
+                                            ,increment))))
+         (declare (ignorable first-line-indent))
+         ,(if need-new-line
+              `(progn (fresh-line stream)
+                      (write-string first-line-indent ,stream)
+                      ;; because we just started a new line, we
+                      ;; should use format/indent to write string
+                      ;; taking into account a main indentation level
+                      (format/indent ,reporter ,stream ,string))
+              ;; otherwise, just output our prefix
+              `(write-string ,string ,stream))
+       
+       
+         ,@body))))
+
+
+
+(defun format/indent (reporter stream control-string &rest format-arguments)
+  "Writes a text to given stream with indentation, dictated by
+*indent-level* and *additional-indent*.
+
+If first line start with ~&, then output will start from a fresh line.
+Otherwise, all lines except the first one are indented."
+  
+  (with-slots (indent-space) reporter
+    (let ((output (apply #'format nil control-string format-arguments)))
+      ;; if string starts with new line, then we have to add indentation
+      ;; otherwise we think it is already written to the stream
+      (when (ppcre:scan "^~&" control-string)
+        (fresh-line stream)
+        (format stream (indent indent-space)))
+
       ;; if this (?!$) is indended to not insert spaces
       ;; into empty lines, then (?m) should be inserted
       ;; before
       ;; TODO: make a pull-request
-      (write-string (ppcre:regex-replace-all "(\\n)(?!$)"
-                                             output
-                                             (format nil "\\1~A" (indent indent-space)))
-                    destination))))
+      (write-string (ppcre:regex-replace-all
+                     "(\\n)(?!$)"
+                     output
+                     (format nil "\\1~A"
+                             (indent indent-space)))
+                    stream))))
+
 
 (defclass reporter ()
   ((indent-space :initform 2)))

--- a/src/reporter/list.lisp
+++ b/src/reporter/list.lisp
@@ -12,10 +12,11 @@
 
 (defmethod format-report (stream (reporter list-reporter) (report comment-report) &rest args)
   (declare (ignore args))
-  (format/indent reporter stream "~& ")
-  (with-color (:white :stream stream)
-    (princ (slot-value report 'description) stream))
-  (terpri stream))
+  (with-additional-indent (reporter stream "~& ")
+    (with-color (:white :stream stream)
+      (format/indent reporter stream (slot-value report 'description)))
+    (terpri stream)))
+
 
 (defun omit-long-value (value)
   (typecase value
@@ -32,19 +33,25 @@
 (defun report-expected-line (report)
   (when (typep report 'normal-test-report)
     (with-slots (got got-form notp report-expected-label expected) report
-      (format nil "~A is ~:[~;not ~]expected to ~:[be~;~:*~A~] ~A~:[ (got ~S)~;~*~]"
-              (omit-long-value (or got-form got))
-              notp
-              report-expected-label
-              (omit-long-value expected)
-              (eq got got-form)
-              got))))
+      (escape-tildes
+       (format nil "~A is ~:[~;not ~]expected to ~:[be~;~:*~A~] ~A~:[ (got ~S)~;~*~]"
+               (omit-long-value (or got-form got))
+               notp
+               report-expected-label
+               (omit-long-value expected)
+               (eq got got-form)
+               got)))))
+
+
+(defun escape-tildes (text)
+  (ppcre:regex-replace-all "~" text "~~"))
+
 
 (defun possible-report-description (report)
   (cond
     ((slot-value report 'description)
      (format nil "~A~:[~; (Skipped)~]"
-             (slot-value report 'description)
+             (escape-tildes (slot-value report 'description))
              (skipped-report-p report)))
     (T (report-expected-line report))))
 
@@ -60,60 +67,58 @@
 
 (defmethod format-report (stream (reporter list-reporter) (report normal-test-report) &rest args)
   (declare (ignore args))
-  (format/indent reporter stream "~&  ")
-  (with-color (:green :stream stream)
-    (format stream "✓"))
-  (let ((description (possible-report-description report))
-        (duration (slot-value report 'duration)))
-    (when description
-      (format stream " ")
-      (with-color (:gray :stream stream)
-        (write-string description stream)))
-    (when duration
-      (format stream " ")
-      (print-duration stream duration (slot-value report 'slow-threshold))))
-  (terpri stream))
+  (with-additional-indent (reporter stream "~&  ")
+    (with-color (:green :stream stream)
+      (with-additional-indent (reporter stream "✓ ")
+        (let ((description (possible-report-description report))
+              (duration (slot-value report 'duration)))
+          (when description
+            (with-color (:gray :stream stream)
+              (format/indent reporter stream description)))
+        
+          (when duration
+            (format stream " ")
+            (print-duration stream duration (slot-value report 'slow-threshold))))
+        (terpri stream)))))
 
 (defmethod format-report (stream (reporter list-reporter) (report skipped-test-report) &rest args)
   (declare (ignore args))
-  (format/indent reporter stream "~&  ")
-  (with-color (:cyan :stream stream)
-    (format stream "-")
-    (let ((description (possible-report-description report)))
-      (when description
-        (format stream " ")
-        (write-string description stream))))
-  (terpri stream))
+  (with-additional-indent (reporter stream "~&  ")
+    (with-color (:cyan :stream stream)
+      (with-additional-indent (reporter stream "- ")
+        (let ((description (possible-report-description report)))
+          (when description
+            (format/indent reporter stream description))))
+      (terpri stream))))
 
 (defmethod format-report (stream (reporter list-reporter) (report failed-test-report) &rest args)
   (declare (ignore args))
-  (format/indent reporter stream "~&  ")
-  (with-color (:red :stream stream)
-    (format stream "×")
-    (let ((description (possible-report-description report))
-          (duration (slot-value report 'duration)))
-      (when description
-        (format stream " ")
-        (write-string description stream))
-      (when duration
-        (format stream " ")
-        (print-duration stream duration (slot-value report 'slow-threshold))))
-    (when (slot-value report 'description)
-      (format/indent reporter stream "~&    ")
-      (princ (report-expected-line report) stream)))
-  (terpri stream))
+  (with-additional-indent (reporter stream "~&  ")
+    (with-color (:red :stream stream)
+      (with-additional-indent (reporter stream "× ")
+        (let ((description (possible-report-description report))
+              (duration (slot-value report 'duration)))
+          (when description
+            (format/indent reporter stream description))
+          (when duration
+            (format stream " ")
+            (print-duration stream duration (slot-value report 'slow-threshold))))
+        (when (slot-value report 'description)
+          (format/indent reporter stream
+                         (concatenate 'string "~&" (report-expected-line report)))))
+      (terpri stream))))
 
 (defmethod format-report (stream (reporter list-reporter) (report error-test-report) &rest args)
   (declare (ignore args))
-  (format/indent reporter stream "~&  ")
-  (with-color (:red :stream stream)
-    (format stream "× ")
-    (when (slot-value report 'description)
-      (format stream "~A~%" (slot-value report 'description))
-      (format/indent reporter stream "    "))
-    (format stream "Raised an error ~A (expected: ~S)"
-            (slot-value report 'got)
-            (slot-value report 'expected)))
+  ;; format/indent
+  (with-additional-indent (reporter stream "~&  ")
+    (with-color (:red :stream stream)
+      (with-additional-indent (reporter stream "× ")
+        (when (slot-value report 'description)
+          (format/indent reporter stream "~A~%" (slot-value report 'description)))
+        (format/indent reporter stream "Raised an error ~A (expected: ~S)"
+                       (slot-value report 'got)
+                       (slot-value report 'expected)))))
   (terpri stream))
 
 (defmethod format-report (stream (reporter list-reporter) (report composed-test-report) &rest args)

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -15,7 +15,8 @@
                 :duration)
   (:import-from :prove.reporter
                 :format-report
-                :*indent-level*)
+                :*indent-level*
+                :*additional-indent*)
   (:import-from :prove.suite
                 :suite
                 :*suite*
@@ -285,7 +286,8 @@
   (diag desc)
   (let ((report
           (let ((*suite* (make-instance 'suite))
-                (*indent-level* (1+ *indent-level*)))
+                (*indent-level* (1+ *indent-level*))
+                (*additional-indent* 0))
             (if *debug-on-error*
                 (funcall body-fn)
                 (handler-case (funcall body-fn)

--- a/t/prove.lisp
+++ b/t/prove.lisp
@@ -8,7 +8,7 @@
 (setf *default-reporter* :list)
 
 
-(plan 19)
+(plan 22)
 
 (test-assertion "Successful OK"
                 (ok t)
@@ -118,5 +118,49 @@ Subtest
 (test-assertion "If condition type mismatch, \"is-error\" fails"
                 (is-error (error 'my-condition) 'simple-error)
                 "(?s)× \\(ERROR ('MY-CONDITION|\\(QUOTE MY-CONDITION\\))\\) is expected to raise a condition SIMPLE-ERROR \\(got #<(a T.PROVE::)?MY-CONDITION.*>\\)")
+
+
+(test-assertion
+ "All lines of multiline description should be indented"
+ (is 'blah 'blah
+     "Blah with multiline
+description!")
+                "
+✓ Blah with multiline
+  description!")
+
+
+(test-assertion
+ "Multiline indentation should work for nested tests"
+ (subtest "Outer testcase
+with multiline
+description."
+   (is 'blah 'blah
+       "Blah with multiline
+description!")
+  
+   (subtest "Inner testcase
+with multiline description."
+     (is 'foo 'foo
+         "Foo with multiline
+description!")))
+                "
+Outer testcase
+with multiline
+description.
+   ✓ Blah with multiline
+     description! 
+  Inner testcase
+  with multiline description.
+     ✓ Foo with multiline
+       description!")
+
+
+(test-assertion "Check finalize's output without a plan"
+                (finalize)
+                "
+△ Tests were run but no plan was declared.
+✓ 0 tests completed (0ms)")
+
 
 (finalize)

--- a/t/utils.lisp
+++ b/t/utils.lisp
@@ -107,7 +107,8 @@ the result before trying to match."
                        ;; tested assert-that macro from modifying real testsuite.
                        ;; Otherwise it can increment failed or success tests count
                        ;; and prove will output wrong data.
-                       (prove.suite:*suite* (make-instance 'prove.suite:suite)))
+                       (prove.suite:*suite* (make-instance 'prove.suite:suite))
+                       (prove.reporter::*debug-indentation* nil))
                    ,body)))
 
               (,trimmed-result (string-trim '(#\Space #\Newline)


### PR DESCRIPTION
### Reasoning

Working on [cl-hamcrest](https://github.com/40ants/cl-hamcrest) I discovered, that it is hard to make tests which have multiline descriptions in Prove. CL-HAMCREST uses them to show failed match in a structured way, to make it easy to see where is wrong data.

In this pull, I've refactored a way how text indentation works inside of Prove.
