### PR TITLE
Follow ASDF recommendations

### DIFF
--- a/cl-test-more.asd
+++ b/cl-test-more.asd
@@ -1,10 +1,5 @@
-(in-package :cl-user)
-(defpackage cl-test-more-asd
-  (:use :cl :asdf))
-(in-package :cl-test-more-asd)
-
-(defsystem cl-test-more
+(defsystem "cl-test-more"
   :version "2.0.0"
   :author "Eitaro Fukamachi"
   :license "MIT"
-  :depends-on (:prove))
+  :depends-on ("prove"))

--- a/prove-asdf.asd
+++ b/prove-asdf.asd
@@ -1,10 +1,4 @@
-(in-package :cl-user)
-
-(defpackage prove-asdf-asd
-  (:use :cl :asdf))
-(in-package :prove-asdf-asd)
-
-(defsystem prove-asdf
+(defsystem "prove-asdf"
   :components ((:module "src"
                 :components
                 ((:file "asdf" :depends-on ("output"))

--- a/prove-test.asd
+++ b/prove-test.asd
@@ -1,10 +1,4 @@
-(in-package :cl-user)
-(defpackage prove-test-asd
-  (:use :cl :asdf))
-(in-package :prove-test-asd)
-
-
-(defsystem prove-test
+(defsystem "prove-test"
   :author "Eitaro Fukamachi"
   :license "MIT"
   :depends-on (:split-sequence
@@ -17,7 +11,5 @@
                   (:test-file "prove"))))
   :description "Test system for Prove."
 
-  :defsystem-depends-on (:prove-asdf)
-  :perform (test-op :after (op c)
-                    (funcall (intern #.(string :run-test-system) :prove-asdf) c)
-                    (asdf:clear-system c)))
+  :defsystem-depends-on ("prove-asdf")
+  :perform (test-op (o c) (symbol-call :prove-asdf :run-test-system c)))

--- a/prove.asd
+++ b/prove.asd
@@ -1,17 +1,12 @@
-(in-package :cl-user)
-(defpackage prove-asd
-  (:use :cl :asdf))
-(in-package :prove-asd)
-
-(defsystem prove
+(defsystem "prove"
   :version "1.0.0"
   :author "Eitaro Fukamachi"
   :license "MIT"
-  :depends-on (:cl-ppcre
-               :cl-ansi-text
-               :cl-colors
-               :alexandria
-               :uiop)
+  :depends-on ("cl-ppcre"
+               "cl-ansi-text"
+               "cl-colors"
+               "alexandria"
+               "uiop")
   :components ((:module "src"
                 :components
                 ((:file "prove" :depends-on ("output" "test" "suite" "asdf" "color"))

--- a/roswell/run-prove.ros
+++ b/roswell/run-prove.ros
@@ -42,8 +42,10 @@ exec ros -Q -- $0 "$@"
                                     (print-error "test file '~A' is not an asd file." test-file))
                                   (let ((test-file (probe-file test-file))
                                         (prove:*enable-colors* color))
-                                    (load test-file)
-                                    (prove:run-test-system (asdf:find-system (pathname-name test-file))))))
+                                    (#+asdf3.3 asdf::with-asdf-session
+                                     #-asdf3.3 asdf::with-asdf-cache ()
+                                      (asdf::load-asd test-file)
+                                      (prove:run-test-system (asdf:find-system (pathname-name test-file)))))))
                               test-files)))))
       (or #.(if (uiop:getenv "COVERALLS")
                 `(,(intern (string :with-coveralls) :coveralls)


### PR DESCRIPTION
Importantly, stop calling clear-system from perform, it's very bad.

Also, use strings as the canonical system name;
stop specifying :after for inline perform method;
stop defining useless and noisy packages.