### PR TITLE
Fix compatibily issue with Allegro CL Modern mode

### DIFF
--- a/prove-aclmm-test.asd
+++ b/prove-aclmm-test.asd
@@ -1,0 +1,15 @@
+(defsystem "prove-aclmm-test"
+  :author "Eitaro Fukamachi"
+  :license "MIT"
+  :depends-on (:split-sequence
+               :alexandria
+               :prove)
+  :components ((:module "t"
+                :serial t
+                :components
+                 ((:file "utils")
+                  (:test-file "prove-aclmm"))))
+  :description "Test system for Prove in Allegro CL modern mode."
+
+  :defsystem-depends-on ("prove-asdf")
+  :perform (test-op (o c) (symbol-call :prove-asdf :run-test-system c)))

--- a/src/asdf.lisp
+++ b/src/asdf.lisp
@@ -77,7 +77,7 @@
   (check-type directory pathname)
   (flet ((always-true (&rest args)
            (declare (ignore args))
-           T))
+           t))
     (let ((directories '()))
       (#+asdf3 uiop:collect-sub*directories
        #-asdf3 asdf::collect-sub*directories
@@ -112,7 +112,7 @@ Example:
          (run (pathname object)))
         ((and (pathnamep object)
               (directory-pathname-p object))
-         (let ((all-passed-p T) (all-passed-files '()) (all-failed-files '()))
+         (let ((all-passed-p t) (all-passed-files '()) (all-failed-files '()))
            (restart-case
                (dolist (file (test-files-in-directory object))
                  (multiple-value-bind (passedp passed-files failed-files)
@@ -136,8 +136,8 @@ Example:
              :report "Skip this test file."
              nil))
          (if (eql (getf *last-suite-report* :failed) 0)
-             (values T (list object) '())
-             (values NIL '() (list object))))
-        (T (run-test-system object))))))
+             (values t (list object) '())
+             (values nil '() (list object))))
+        (t (run-test-system object))))))
 
 (import 'test-file :asdf)

--- a/src/color.lisp
+++ b/src/color.lisp
@@ -27,7 +27,7 @@
      `(if *enable-colors*
           (with-gray ,(or (getf args :stream) t) ,@body)
           (progn ,@body)))
-    (T `(if *enable-colors*
+    (t `(if *enable-colors*
             (if (or (eq ,color :gray)
                     (eq ,color :grey)
                     (eq ,color cl-colors:+gray+)

--- a/src/reporter/dot.lisp
+++ b/src/reporter/dot.lisp
@@ -21,7 +21,7 @@
         (with-color ((cond
                        ((failed-report-p report) :red)
                        ((skipped-report-p report) :cyan)
-                       (T :gray)) :stream stream)
+                       (t :gray)) :stream stream)
           (format stream (if (error-report-p report)
                              "x"
                              ".")))

--- a/src/reporter/fiveam.lisp
+++ b/src/reporter/fiveam.lisp
@@ -30,7 +30,7 @@
                       notp
                       report-expected-label
                       expected))
-      (T (format/indent reporter stream "~& ~:[(no description)~;~:*~A~]: Failed~%"
+      (t (format/indent reporter stream "~& ~:[(no description)~;~:*~A~]: Failed~%"
                         description)))))
 
 (defmethod print-error-report ((reporter fiveam-reporter) (report composed-test-report) stream)

--- a/src/reporter/list.lisp
+++ b/src/reporter/list.lisp
@@ -58,7 +58,7 @@
      (format nil "~A~:[~; (Skipped)~]"
              (escape-tildes (slot-value report 'description))
              (skipped-report-p report)))
-    (T (report-expected-line report))))
+    (t (report-expected-line report))))
 
 (defun print-duration (stream duration &optional slow-threshold)
   (let ((color (if slow-threshold

--- a/src/suite.lisp
+++ b/src/suite.lisp
@@ -57,7 +57,7 @@
 (defun find-package-suite (package-designator)
   (let ((package (typecase package-designator
                    (package package-designator)
-                   (T (find-package package-designator)))))
+                   (t (find-package package-designator)))))
     (or (gethash (package-name package) *defined-suites*)
         (setf (gethash (package-name package) *defined-suites*)
               (make-instance 'package-suite)))))

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -147,7 +147,7 @@
 (defmacro ok (test &optional desc)
   (with-gensyms (duration result)
     (once-only (test desc)
-      `(with-catching-errors (:expected T :description ,desc)
+      `(with-catching-errors (:expected t :description ,desc)
          (with-duration ((,duration ,result) ,test)
            (test ,result t ,desc
                  :duration ,duration
@@ -344,7 +344,7 @@
 (defun run-test-package (package-designator)
   (let ((*package* (typecase package-designator
                      (package package-designator)
-                     (T (find-package package-designator)))))
+                     (t (find-package package-designator)))))
     (loop for (name . test-fn) in (reverse (gethash *package* *package-tests*))
           do (funcall test-fn))
     (finalize)))

--- a/t/prove-aclmm.lisp
+++ b/t/prove-aclmm.lisp
@@ -1,0 +1,166 @@
+(in-package :cl-user)
+(defpackage t.prove
+  (:use :cl
+        :prove
+        :prove.t.utils))
+(in-package :t.prove)
+
+(setf *default-reporter* :list)
+
+
+(plan 22)
+
+(test-assertion "Successful OK"
+                (ok t)
+                "✓ t is expected to be t")
+
+
+(test-assertion "Failed ok without description"
+                (ok nil)
+                "× nil is expected to be t")
+
+
+(test-assertion "Failed ok with description"
+                (ok nil "This supposed to be failed")
+                "
+× This supposed to be failed 
+  nil is expected to be t")
+
+
+(test-assertion "Simple number equality check"
+                (is 1 1)
+                "✓ 1 is expected to be 1")
+
+
+(test-assertion "String and number shouldn't be equal"
+                (is "1" 1)
+                "× \"1\" is expected to be 1")
+
+
+(test-assertion "String and number are not equal and isnt assertion returns OK"
+                (isnt "1" 1)
+                "✓ \"1\" is not expected to be 1")
+
+
+(test-assertion "Subtest with diagnostic message"
+ (subtest "Subtest"
+   (diag "in subtest")
+   (is #\a #\a)
+   (like "truth" "^true"))
+"
+Subtest
+  in subtest
+   ✓ #\\a is expected to be #\\a 
+   × \"truth\" is expected to be like \"^true\"")
+
+
+(test-assertion "Check if (is-values ...) works propertly"
+                (is-values (values 1 2 nil 3)
+                           '(1 2 nil 3))
+                "✓ (1 2 nil 3) is expected to be (1 2 nil 3)")
+
+
+(test-assertion "Standalone diagnostic message"
+                (diag "comment")
+                "comment")
+
+
+(test-assertion "Just a pass"
+                (pass "pass")
+                "✓ pass")
+
+
+(test-assertion "Fail"
+                (fail "fail")
+                "
+× fail
+  t is expected to be nil")
+
+
+(test-assertion "Pass with parameter"
+                (pass "<~S>")
+                "✓ <~S>")
+
+
+(test-assertion "Equality for strings with formatting"
+                (is "<~S>" "<~S>")
+                "✓ \"<~S>\" is expected to be \"<~S>\"")
+
+
+(test-assertion "\"Skip\" with reason as control-string with arguments should substitute arguments"
+                (skip 1 "Because ~A" 42)
+                "- Because 42 (Skipped)")
+
+
+(test-assertion "\"Skip\" without reason have default message \"skipping\""
+                (skip 1 "skipping")
+                "- skipping (Skipped)")
+
+
+(test-assertion "Assert is-print compares form's output to standart-output"
+                (is-print (princ "ABCDEFGH")
+                                 "ABCDEFGHIJKLMNO")
+                "× (princ \"ABCDEFGH\") is expected to output \"ABCDEFGHIJKLMNO\" (got \"ABCDEFGH\")")
+
+
+(test-assertion "Type assertion fails if type mismatch"
+                (is-type 1 'string)
+                "× 1 is expected to be a type of string")
+
+
+(test-assertion "Assertion \"is-error\" checks if condition of given type was thrown"
+                (is-error (error "Raising an error") 'simple-error)
+                "(?s)✓ \\(error \"Raising an error\"\\) is expected to raise a condition simple-error \\(got #<(a )?simple-error.*>\\)")
+
+
+(define-condition my-condition () ())
+
+(test-assertion "If condition type mismatch, \"is-error\" fails"
+                (is-error (error 'my-condition) 'simple-error)
+                "(?s)× \\(error ('my-condition|\\(quote my-condition\\))\\) is expected to raise a condition simple-error \\(got #<(a t.prove::)?my-condition.*>\\)")
+
+
+(test-assertion
+ "All lines of multiline description should be indented"
+ (is 'blah 'blah
+     "Blah with multiline
+description!")
+                "
+✓ Blah with multiline
+  description!")
+
+
+(test-assertion
+ "Multiline indentation should work for nested tests"
+ (subtest "Outer testcase
+with multiline
+description."
+   (is 'blah 'blah
+       "Blah with multiline
+description!")
+  
+   (subtest "Inner testcase
+with multiline description."
+     (is 'foo 'foo
+         "Foo with multiline
+description!")))
+                "
+Outer testcase
+with multiline
+description.
+   ✓ Blah with multiline
+     description! 
+  Inner testcase
+  with multiline description.
+     ✓ Foo with multiline
+       description!")
+
+
+(test-assertion "Check finalize's output without a plan"
+                (finalize)
+                "
+△ Tests were run but no plan was declared.
+✓ 0 tests completed (0ms)")
+
+
+(finalize)


### PR DESCRIPTION
Change symbols to lower case, this trivial change allow `prove` to be used successfully under Allegro CL Modern mode (see http://franz.com/support/documentation/current/doc/case.htm).

I added a separate system definition for the ACL tests because I was uncomfortable with messing with the tests of the test framework :thinking:.

__Tested with__

* Allegro CL 10.1 ANSI and Modern modes
* SBCL 1.3.18